### PR TITLE
Strat statuses

### DIFF
--- a/source/includes/_strategy.md
+++ b/source/includes/_strategy.md
@@ -25,11 +25,11 @@ schema: https://opendataproducts.org/v4.1/schema/odps.yaml
 version: 4.1
 product:
   productStrategy:
+    status: planned
     objectives:
       - en: Reduce emergency response time
     strategicAlignment:
       - en: Smart City Vision 2030
-    status: planned
     contributesToKPI:
       id: bizkpi-city-response-time
       name: City Emergency Response Time

--- a/source/schema/odps.json
+++ b/source/schema/odps.json
@@ -331,6 +331,19 @@
             "type": "object",
             "description": "Connects the data product to business objectives and KPIs.",
             "properties": {
+                "status": {
+                "type": "string",
+                "description": "Execution status of the product strategy.",
+                "enum": [
+                    "Planned",
+                    "Active",
+                    "At Risk",
+                    "Achieved",
+                    "Partially Achieved",
+                    "Cancelled",
+                    "Expired"
+                ]
+                },
                 "objectives": {
                     "type": "array",
                     "items": {

--- a/source/schema/odps.yaml
+++ b/source/schema/odps.yaml
@@ -51,6 +51,16 @@ properties:
       productStrategy:
         type: object
         properties:
+          status:
+            type: string
+            enum:
+              - Planned
+              - Active
+              - At Risk
+              - Achieved
+              - Partially Achieved
+              - Cancelled
+              - Expired
           objectives:
             type: array
             items:


### PR DESCRIPTION
### Reference to related issue ###
#5 


This PR adds a status field to productStrategy and updates both the YAML and JSON Schemas.

**Change**

New field: productStrategy.status

Allowed values: Planned, Active, At Risk, Achieved, Partially Achieved, Cancelled, Expired

**Rationale**
Separates strategy execution status from product lifecycle status and supports governance and reporting.

**Breaking changes**
None


### ---- Leave intact! Approval of Contributor Agreement ----- ### 
By submitting pull request you approve the Contributor Agreement, https://governance.opendataproducts.org/v1/contributions/contributor-agreement 