### PR TITLE
Start Date and End date added

### DIFF
--- a/source/includes/_strategy.md
+++ b/source/includes/_strategy.md
@@ -25,7 +25,9 @@ schema: https://opendataproducts.org/v4.1/schema/odps.yaml
 version: 4.1
 product:
   productStrategy:
-    status: planned
+    status: Planned
+    startDate: 2026-01-12
+    endDate: 2026-06-30
     objectives:
       - en: Reduce emergency response time
     strategicAlignment:
@@ -72,6 +74,8 @@ product:
 | **id** | string | optional | Identifier of the business KPI (use shared IDs for roll‑ups). |
 | **name** | string | required | KPI name. |
 | **status** | string | One of: Planned, Active, At Risk, Achieved, Partially Achieved, Cancelled, Expired | Indicates the status of the strategy object. Consider this similar to data product lifecycle status. |
+| **startDate** | string (date) | ISO 8601 date (YYYY-MM-DD) | Indicates when the product strategy becomes active. Used for timeline and Gantt chart visualizations. |
+| **endDate**   | string (date) | ISO 8601 date (YYYY-MM-DD) | Indicates when the product strategy ends or is planned to end. Used for timeline and Gantt chart visualizations. |
 | **description** | string | optional | Human‑readable description. |
 | **unit** | string | e.g., `percentage`, `minutes`, `s` | Unit of measurement. |
 | **target** | number/string | – | Target value for the KPI. |

--- a/source/schema/odps.json
+++ b/source/schema/odps.json
@@ -344,6 +344,16 @@
                     "Expired"
                 ]
                 },
+                "startDate": {
+                "type": "string",
+                "format": "date",
+                "description": "Date when the product strategy becomes active. Used for timeline and Gantt chart visualizations."
+                },
+                "endDate": {
+                "type": "string",
+                "format": "date",
+                "description": "Date when the product strategy ends or is planned to end. Used for timeline and Gantt chart visualizations."
+                },
                 "objectives": {
                     "type": "array",
                     "items": {

--- a/source/schema/odps.yaml
+++ b/source/schema/odps.yaml
@@ -61,6 +61,17 @@ properties:
               - Partially Achieved
               - Cancelled
               - Expired
+          
+          startDate:
+            type: string
+            format: date
+            description: Date when the product strategy becomes active. Use ISO 8601, (YYYY-MM-DD).
+
+          endDate:
+            type: string
+            format: date
+            description: Date when the product strategy ends or is planned to end. Use ISO 8601, (YYYY-MM-DD).
+
           objectives:
             type: array
             items:


### PR DESCRIPTION
Added to spec and in both Schemas. Schema changes validated.


### Reference to related issue ###
#4 

### Summary

This PR extends the `productStrategy` object in ODPS 4.1 by adding explicit strategy execution metadata. A new `status` attribute and optional `startDate` and `endDate` fields are introduced to both the YAML and JSON Schemas.

The change enables clear tracking of strategy state and duration, supports timeline and Gantt-style visualizations, and cleanly separates strategy execution from data product lifecycle status. The update is backward-compatible and does not introduce new required fields.



### ---- Leave intact! Approval of Contributor Agreement ----- ### 
By submitting pull request you approve the Contributor Agreement, https://governance.opendataproducts.org/v1/contributions/contributor-agreement 