### PR TITLE
Add governanceProfile and integer weight for DQ/SLA

### DIFF
--- a/source/examples/Refs/urbanpulse_basic.yml
+++ b/source/examples/Refs/urbanpulse_basic.yml
@@ -1,5 +1,5 @@
-schema: 'https://opendataproducts.org/v3.1/schema/odps.yaml'
-version: 3.1
+schema: 'https://opendataproducts.org/v4.1/schema/odps.yaml'
+version: 4.1
 product:
   contract:
     id: 02323M123
@@ -55,12 +55,15 @@ product:
             en: Uptime
           objective: 90
           unit: percent
+          weight: 50
         - dimension: responseTime
           objective: 200
           unit: milliseconds
+          weight: 30
         - dimension: updateFrequency
           objective: 30
           unit: minutes
+          weight: 20
   dataQuality:
     default:
       displaytitle:
@@ -78,11 +81,13 @@ product:
               reliable insights.
           objective: 90
           unit: percentage
+          weight: 60
         - dimension: completeness
           displaytitle:
             en: Data Completeness (percent)
           objective: 90
           unit: percentage
+          weight: 40
   dataAccess:
     default:
       name:

--- a/source/examples/Refs/urbanpulse_internal.yml
+++ b/source/examples/Refs/urbanpulse_internal.yml
@@ -1,5 +1,5 @@
-schema: 'https://opendataproducts.org/v3.1/schema/odps.yaml'
-version: 3.1
+schema: 'https://opendataproducts.org/v4.1/schema/odps.yaml'
+version: 4.1
 product:
   contract:
     id: 02323M123
@@ -121,12 +121,15 @@ product:
             en: Uptime
           objective: 90
           unit: percent
+          weight: 50
         - dimension: responseTime
           objective: 200
           unit: milliseconds
+          weight: 30
         - dimension: updateFrequency
           objective: 30
           unit: minutes
+          weight: 20
     premium:
       name:
         en: The Premium SLA
@@ -138,12 +141,15 @@ product:
             en: Uptime
           objective: 99
           unit: percent
+          weight: 70
         - dimension: responseTime
           objective: 100
           unit: milliseconds
+          weight: 20
         - dimension: updateFrequency
           objective: 5
           unit: minutes
+          weight: 10
   dataQuality:
     default:
       displaytitle:
@@ -161,11 +167,13 @@ product:
               reliable insights.
           objective: 90
           unit: percentage
+          weight: 60
         - dimension: completeness
           displaytitle:
             en: Data Completeness (percent)
           objective: 90
           unit: percentage
+          weight: 40
     premium:
       displaytitle:
         en: The Premium Data Quality
@@ -182,11 +190,13 @@ product:
               reliable insights.
           objective: 98
           unit: percentage
+          weight: 80
         - dimension: completeness
           displaytitle:
             en: Data Completeness (percent)
           objective: 99
           unit: percentage
+          weight: 20
   dataAccess:
     default:
       name:

--- a/source/includes/_qa.md
+++ b/source/includes/_qa.md
@@ -12,11 +12,13 @@ dataQuality:
             en: Data Accuracy (percent)
           objective: 90
           unit: percentage
+          weight: 60
         - dimension: completeness
           displaytitle:
             - en: Data Completeness (percent)
           objective: 90
           unit: percentage
+          weight: 40
   executable:
     - dimension: selected dimension
       type:  
@@ -115,11 +117,13 @@ dataQuality:
               reliable insights.
           objective: 90
           unit: percentage
+          weight: 60
         - dimension: completeness
           displaytitle:
             - en: Data Completeness (percent)
           objective: 90
           unit: percentage
+          weight: 40
 
 
     premium:
@@ -138,11 +142,13 @@ dataQuality:
               reliable insights.
           objective: 98
           unit: percentage
+          weight: 70
         - dimension: completeness
           displaytitle:
             en: Data Completeness (percent)
           objective: 99
           unit: percentage
+          weight: 30
 
   executable:
     - dimension: accuracy
@@ -198,6 +204,7 @@ dataQuality:
 | **dimension** | attribute | string, one of: *accuracy, completeness, conformity, consistency, coverage, timeliness, validity, or uniqueness.* | Defines the data quality dimension. |
 | **objective** | attribute | integer | Defines the target value for the data quality dimension |
 | **unit** | attribute | string. One of: *percentage, number* | Defines the unit used in stating the target quality level. |
+| **weight** | attribute | integer | Optional. Relative importance as percentage of the dimension when calculating the product's overall Data Quality score. Must be an integer (no decimals). |
 | **executable** | element | - | Grouping element that collects together data quality monitoring rules. You can define monitoring patterns as code under this element for each dimension. The actual as-code part is defined in the `spec` element. |
 | **displaytitle** | array | - | Dimension title to be shown in various UIs. Array contains title(s) in desired language(s). |
 | **en** | attribute | [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) defined 2-letter codes | Binds the text elements together in a given language. Multilanguage support is implemented by duplicating content under other ISO language codes. |
@@ -206,6 +213,8 @@ dataQuality:
 | **version** | attribute | string | The version of DQ monitoring tool used. |
 | **reference** | URL | Valid URL | Provide URL pointing to the reference documentation. |
 | **spec** | element | YAML/URL/string | The content for Data Quality monitoring expressed as code. Accepted as inline YAML, a valid URL pointing to YAML, or a plain string if `type` is `Custom`. |
+
+
 
 
 If you see something missing, described inaccurately or plain wrong, or you want to comment the specification, [raise an issue in Github](https://github.com/Open-Data-Product-Initiative/dev/issues)

--- a/source/includes/_sla.md
+++ b/source/includes/_sla.md
@@ -70,9 +70,11 @@ SLA:
         - en: Uptime
       objective: 99
       unit: percent
+      weight: 50
     - dimension: responseTime
       objective: 200
       unit: milliseconds
+      weight: 30
 
 ```
 
@@ -111,12 +113,15 @@ SLA:
             en: Uptime
           objective: 90
           unit: percent
+          weight: 50
         - dimension: responseTime
           objective: 200
           unit: milliseconds
+          weight: 30
         - dimension: updateFrequency
           objective: 30
           unit: minutes
+          weight: 20
     premium:
       name: 
         en: The Premium SLA
@@ -128,12 +133,15 @@ SLA:
             en: Uptime
           objective: 99
           unit: percent
+          weight: 70
         - dimension: responseTime
           objective: 100
           unit: milliseconds
+          weight: 20
         - dimension: updateFrequency
           objective: 5
           unit: minutes
+          weight: 10
   executable:
     - dimension: uptime
       type: prometheus
@@ -193,6 +201,7 @@ SLA:
 | **dimension** | attribute | string, one of: *latency, uptime, responseTime, errorRate, endOfSupport, endOfLife, updateFrequency, timeToDetect, timeToNotify, timeToRepair, emailResponseTime* | Defines the SLA dimension. |
 | **objective** | attribute | integer | Target level to be achieved for the dimension (e.g., 99). |
 | **unit** | attribute | Options: percent, milliseconds, seconds, minutes, days, weeks, months, years, never, date, null | Measurement unit for the SLA objective. If "date" is used, format should be dd/mm/yyyy. |
+| **weight** | attribute | integer | Optional. Relative importance as percentage of the SLA dimension when calculating the product's overall SLA score. Must be an integer (no decimals). User-editable. |
 | **displayTitle** | array | - | Dimension title to be shown in UIs. Localized per language. |
 | **description** | array | - | Description of the SLA package or specific dimension, localized per language. |
 | **executable** | element | - | Grouping element for SLA monitoring logic. Monitoring definitions are provided as code in the `spec` field for each dimension. |

--- a/source/schema/odps.json
+++ b/source/schema/odps.json
@@ -579,6 +579,10 @@
                     ],
                     "description": "Target level to be achieved for the dimension."
                 },
+                "weight": {
+                    "type": "integer",
+                    "description": "Relative importance of this SLA dimension for product-level scoring. User-editable integer (no decimals)."
+                },
                 "unit": {
                     "type": "string",
                     "enum": [
@@ -635,6 +639,10 @@
                 "objective": {
                     "type": "integer",
                     "description": "Defines the target value for the data quality dimension."
+                },
+                "weight": {
+                    "type": "integer",
+                    "description": "Relative importance of this Data Quality dimension when calculating the product's overall Data Quality score. User-editable integer (no decimals)."
                 },
                 "unit": {
                     "type": "string",

--- a/source/schema/odps.yaml
+++ b/source/schema/odps.yaml
@@ -198,6 +198,16 @@ properties:
                   items:
                     type: object
                     required: [dimension, objective, unit]
+                    properties:
+                      dimension:
+                        type: string
+                      objective:
+                        type: integer
+                      unit:
+                        type: string
+                      weight:
+                        type: integer
+                        description: Relative importance of this dimension for product-level scoring. User-editable integer (no decimals).
 
       dataQuality:
         type: object
@@ -217,6 +227,16 @@ properties:
                   items:
                     type: object
                     required: [dimension, objective, unit]
+                    properties:
+                      dimension:
+                        type: string
+                      objective:
+                        type: integer
+                      unit:
+                        type: string
+                      weight:
+                        type: integer
+                        description: Relative importance of this dimension for product-level scoring. User-editable integer (no decimals).
 
       dataAccess:
         type: object


### PR DESCRIPTION


Adds optional governanceProfile to product.details (values: structured, enforced, automated, audit_ready) and an optional integer weight to SLA and Data Quality dimension definitions to express relative importance for product-level scoring. Both JSON and YAML schemas parse successfully.


### Reference to related issue ###
#12 


### ---- Leave intact! Approval of Contributor Agreement ----- ### 
By submitting pull request you approve the Contributor Agreement, https://governance.opendataproducts.org/v1/contributions/contributor-agreement 